### PR TITLE
Add sha1 output support if sha1s are not provided

### DIFF
--- a/assets/in
+++ b/assets/in
@@ -64,6 +64,10 @@ if [ "$fetch_tarball" = "true" ]; then
   if ! download_tarball "$url" "$destination" "$md5" "$sha1"; then
     exit 1
   fi
+  # if we have successfully downloaded the tarball, and there's no sha1 provided, gen one
+  if [ "$sha1" == "" ]; then
+    sha1=$(sha1_of $destination/stemcell.tgz)
+  fi
 fi
 
 jq -n '{


### PR DESCRIPTION
After the stemcell tarball is downloaded and checksum-verified,
if no sha1 was provided in metadata from the bosh.io API,
calculate a sha1sum, and provide that as output from the resource.
