### PR TITLE
[WIP] Only fetch light stemcells for IaaS which provide light stemcells

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ resources:
 ## Source Configuration
 
 * `name`: *Required.* The name of the stemcell.
-
+* `force_heavy`: *Optional.* Default `false`. By default, the resource will always download light stemcells for IaaS that support light stemcells. If `force_heavy` is `true`, the resource will ignore light stemcells and always download heavy stemcells.
 
 ## Behavior
 

--- a/assets/check
+++ b/assets/check
@@ -14,6 +14,7 @@ payload=$(mktemp $TMPDIR/bosh-io-stemcell-resource-request.XXXXXX)
 cat > $payload <&0
 
 name=$(jq -r '.source.name // ""' < $payload)
+force_heavy=$(jq -r '.source.force_heavy // false' < $payload)
 current_version=$(jq -r '.version.version // ""' < $payload)
 
 if [ -z "$name" ]; then
@@ -24,6 +25,14 @@ fi
 stemcells=$(mktemp $TMPDIR/bosh-io-stemcell-versions.XXXXXX)
 
 curl --retry 5 -L -s -f https://bosh.io/api/v1/stemcells/$name -o $stemcells
+
+supports_light=$(jq 'any(select(.light))' < $stemcells)
+if [ "$supports_light" == 'true' ] && [ "$force_heavy" != 'true' ]; then
+  jq 'map(select(.light))' < $stemcells > $stemcells.new
+else
+  jq 'map(select(.regular))' < $stemcells > $stemcells.new
+fi
+mv -f $stemcells.new $stemcells
 
 last_idx=0
 if [ -z "$current_version" ]; then

--- a/assets/in
+++ b/assets/in
@@ -11,6 +11,7 @@ payload=$(mktemp $TMPDIR/bosh-io-stemcell-resource-request.XXXXXX)
 cat > $payload <&0
 
 name=$(jq -r '.source.name // ""' < $payload)
+force_heavy=$(jq -r '.source.force_heavy // false' < $payload)
 version=$(jq -r '.version.version // ""' < $payload)
 fetch_tarball=$(jq -r '.params.tarball != false' < $payload)
 
@@ -40,9 +41,15 @@ curl \
   --retry 5 \
   --fail \
   --location \
-  "http://bosh.io/api/v1/stemcells/$name" | \
-  jq 'map(select(.version == $version))[0] | .light // .regular' --arg version "$version" > \
-  $stemcell_data
+  "http://bosh.io/api/v1/stemcells/$name" > $stemcell_data
+
+supports_light=$(jq 'any(select(.light))' < $stemcell_data)
+if [ "$supports_light" == 'true' ] && [ "$force_heavy" != 'true' ]; then
+  jq 'map(select(.version == $version))[0].light' --arg version "$version" < $stemcell_data > $stemcell_data.new
+else
+  jq 'map(select(.version == $version))[0].regular' --arg version "$version" < $stemcell_data > $stemcell_data.new
+fi
+mv -f $stemcell_data.new $stemcell_data
 
 url=$(jq -r .url < $stemcell_data)
 sha1=$(jq -r .sha1 < $stemcell_data)


### PR DESCRIPTION
- The bosh team is switching up how we produce light stemcells which will
  result in heavy stemcells being published a bit before the light stemcells
- We don't want Concourse users to accidentally fetch the heavy AWS stemcell
  instead of the light as you can't deploy a heavy stemcell from within Concourse
- This change will check for only light stemcells (if the IaaS has light stemcells)
  unless overridden by `source.force_heavy: true`. IaaS with only heavy stemcells
  like vSphere will always fetch heavy stemcells as normal

[#127591235](https://www.pivotaltracker.com/story/show/127591235)

Signed-off-by: Lyle Franklin lfranklin@pivotal.io
