### PR TITLE
Stemcell version regex

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,9 @@
 FROM concourse/buildroot:curl
 
 ADD assets/ /opt/resource/
+
+RUN mkdir -p /opt/jq
+RUN curl -L https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64 -o /opt/jq/jq
+
+RUN chmod +x /opt/jq/jq
 RUN chmod +x /opt/resource/*

--- a/assets/check
+++ b/assets/check
@@ -7,13 +7,14 @@ exec 3>&1 # make stdout available as fd 3 for the result
 exec 1>&2 # redirect all output to stderr for logging
 
 # for jq
-PATH=/usr/local/bin:$PATH
+PATH=/opt/jq:$PATH
 
 payload=$(mktemp $TMPDIR/bosh-io-stemcell-resource-request.XXXXXX)
 
 cat > $payload <&0
 
 name=$(jq -r '.source.name // ""' < $payload)
+version_regex=$(jq -r '.source.version // ""' < $payload )
 current_version=$(jq -r '.version.version // ""' < $payload)
 
 if [ -z "$name" ]; then
@@ -21,9 +22,14 @@ if [ -z "$name" ]; then
   exit 1
 fi
 
-stemcells=$(mktemp $TMPDIR/bosh-io-stemcell-versions.XXXXXX)
+if [ -z $version_regex ]; then
+  version_regex='.*'
+fi
 
-curl --retry 5 -L -s -f https://bosh.io/api/v1/stemcells/$name -o $stemcells
+stemcells=$(mktemp $TMPDIR/bosh-io-stemcell-versions.XXXXXX)
+curl --retry 5 -L -s -f https://bosh.io/api/v1/stemcells/$name | jq --arg regex "$version_regex" '[.[] | select(.version | test($regex))]' > $stemcells
+
+cat $stemcells
 
 last_idx=0
 if [ -z "$current_version" ]; then
@@ -39,4 +45,5 @@ else
   fi
 fi
 
+echo $last_idx
 jq ".[0:$last_idx] | map({version}) | reverse" < $stemcells >&3

--- a/assets/check
+++ b/assets/check
@@ -29,8 +29,6 @@ fi
 stemcells=$(mktemp $TMPDIR/bosh-io-stemcell-versions.XXXXXX)
 curl --retry 5 -L -s -f https://bosh.io/api/v1/stemcells/$name | jq --arg regex "$version_regex" '[.[] | select(.version | test($regex))]' > $stemcells
 
-cat $stemcells
-
 last_idx=0
 if [ -z "$current_version" ]; then
   last_idx=1
@@ -45,5 +43,4 @@ else
   fi
 fi
 
-echo $last_idx
 jq ".[0:$last_idx] | map({version}) | reverse" < $stemcells >&3


### PR DESCRIPTION
We have found it useful to lock stemcells to a version. This PR adds an optional source field `version` that takes a regex for the version. The check step gets the most recent stemcell matching version_regex. 
