### PR TITLE
Add `force_regular` property and fine-tune light vs regular behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,9 @@ resources:
 ## Source Configuration
 
 * `name`: *Required.* The name of the stemcell.
-
+* `force_regular`: *Optional.* Default `false`. By default, the resource will always download light stemcells for IaaSes
+  that support light stemcells. If `force_regular` is `true`, the resource will ignore light stemcells and always
+  download regular stemcells.
 
 ## Behavior
 

--- a/acceptance/check_test.go
+++ b/acceptance/check_test.go
@@ -65,12 +65,12 @@ var _ = Describe("check", func() {
 
 			result := []stemcellVersion{}
 			err = json.Unmarshal(session.Out.Contents(), &result)
-			Expect(err).ToNot(HaveOccurred())
+			Expect(err).NotTo(HaveOccurred())
 
 			Expect(result).To(HaveLen(1))
-			Expect(result[0]["version"]).ToNot(BeEmpty())
-			Expect(result[0]["version"]).ToNot(Equal("3262.7"))
-			Expect(result[0]["version"]).ToNot(Equal("3262.5"))
+			Expect(result[0]["version"]).NotTo(BeEmpty())
+			Expect(result[0]["version"]).NotTo(Equal("3262.7"))
+			Expect(result[0]["version"]).NotTo(Equal("3262.5"))
 		})
 	})
 
@@ -91,7 +91,7 @@ var _ = Describe("check", func() {
 
 			result := []stemcellVersion{}
 			err = json.Unmarshal(session.Out.Contents(), &result)
-			Expect(err).ToNot(HaveOccurred())
+			Expect(err).NotTo(HaveOccurred())
 
 			Expect(result).To(ContainElement(stemcellVersion{
 				"version": "3262.7",
@@ -102,14 +102,13 @@ var _ = Describe("check", func() {
 			Expect(result).To(ContainElement(stemcellVersion{
 				"version": "3262.4.1",
 			}))
-			Expect(result).ToNot(ContainElement(stemcellVersion{
+			Expect(result).NotTo(ContainElement(stemcellVersion{
 				"version": "3262.2",
 			}))
 		})
 	})
 
 	Context("when `force_regular` is true", func() {
-
 		Context("and regular stemcell versions are available", func() {
 			var command *exec.Cmd
 
@@ -127,10 +126,10 @@ var _ = Describe("check", func() {
 
 				result := []stemcellVersion{}
 				err = json.Unmarshal(session.Out.Contents(), &result)
-				Expect(err).ToNot(HaveOccurred())
+				Expect(err).NotTo(HaveOccurred())
 
 				Expect(result).To(HaveLen(1))
-				Expect(result[0]["version"]).ToNot(BeEmpty())
+				Expect(result[0]["version"]).NotTo(BeEmpty())
 			})
 		})
 
@@ -151,7 +150,7 @@ var _ = Describe("check", func() {
 
 				result := []stemcellVersion{}
 				err = json.Unmarshal(session.Out.Contents(), &result)
-				Expect(err).ToNot(HaveOccurred())
+				Expect(err).NotTo(HaveOccurred())
 
 				Expect(result).To(HaveLen(0))
 			})

--- a/acceptance/in_test.go
+++ b/acceptance/in_test.go
@@ -39,6 +39,27 @@ const regularStemcellRequest = `
 	}
 }`
 
+const bothTypesStemcellRequest = `
+{
+	"source": {
+		"name": "bosh-aws-xen-ubuntu-trusty-go_agent"
+	},
+	"version": {
+		"version": "3262.4"
+	}
+}`
+
+const bothTypesForceRegularStemcellRequest = `
+{
+	"source": {
+		"name": "bosh-aws-xen-ubuntu-trusty-go_agent",
+		"force_regular": true
+	},
+	"version": {
+		"version": "3262.4"
+	}
+}`
+
 const stemcellRequestWithFileName = `
 {
 	"source": {
@@ -146,6 +167,86 @@ var _ = Describe("in", func() {
 				Expect(err).NotTo(HaveOccurred())
 				Expect(string(checksum)).To(Equal(fmt.Sprintf("%x", sha1.Sum(tarballBytes))))
 			})
+		})
+	})
+
+	Context("when a stemcell is requested that supports both light and regular", func() {
+		var (
+			command    *exec.Cmd
+			contentDir string
+		)
+
+		BeforeEach(func() {
+			var err error
+			contentDir, err = ioutil.TempDir("", "")
+			Expect(err).NotTo(HaveOccurred())
+
+			command = exec.Command(boshioIn, contentDir)
+			command.Stdin = bytes.NewBufferString(bothTypesStemcellRequest)
+		})
+
+		AfterEach(func() {
+			err := os.RemoveAll(contentDir)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("downloads the light stemcell with metadata", func() {
+			session, err := gexec.Start(command, GinkgoWriter, GinkgoWriter)
+			Expect(err).NotTo(HaveOccurred())
+
+			<-session.Exited
+			Expect(session.ExitCode()).To(Equal(0))
+
+			tarballBytes, err := ioutil.ReadFile(filepath.Join(contentDir, "stemcell.tgz"))
+			Expect(err).NotTo(HaveOccurred())
+
+			checksum, err := ioutil.ReadFile(filepath.Join(contentDir, "sha1"))
+			Expect(err).NotTo(HaveOccurred())
+			Expect(string(checksum)).To(Equal(fmt.Sprintf("%x", sha1.Sum(tarballBytes))))
+
+			urlBytes, err := ioutil.ReadFile(filepath.Join(contentDir, "url"))
+			Expect(err).NotTo(HaveOccurred())
+			Expect(string(urlBytes)).To(ContainSubstring("light"))
+		})
+	})
+
+	Context("when a stemcell is requested that supports both light and regular and force_regular is true", func() {
+		var (
+			command    *exec.Cmd
+			contentDir string
+		)
+
+		BeforeEach(func() {
+			var err error
+			contentDir, err = ioutil.TempDir("", "")
+			Expect(err).NotTo(HaveOccurred())
+
+			command = exec.Command(boshioIn, contentDir)
+			command.Stdin = bytes.NewBufferString(bothTypesForceRegularStemcellRequest)
+		})
+
+		AfterEach(func() {
+			err := os.RemoveAll(contentDir)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("downloads the regular stemcell with metadata", func() {
+			session, err := gexec.Start(command, GinkgoWriter, GinkgoWriter)
+			Expect(err).NotTo(HaveOccurred())
+
+			<-session.Exited
+			Expect(session.ExitCode()).To(Equal(0))
+
+			tarballBytes, err := ioutil.ReadFile(filepath.Join(contentDir, "stemcell.tgz"))
+			Expect(err).NotTo(HaveOccurred())
+
+			checksum, err := ioutil.ReadFile(filepath.Join(contentDir, "sha1"))
+			Expect(err).NotTo(HaveOccurred())
+			Expect(string(checksum)).To(Equal(fmt.Sprintf("%x", sha1.Sum(tarballBytes))))
+
+			urlBytes, err := ioutil.ReadFile(filepath.Join(contentDir, "url"))
+			Expect(err).NotTo(HaveOccurred())
+			Expect(string(urlBytes)).ToNot(ContainSubstring("light"))
 		})
 	})
 

--- a/acceptance/in_test.go
+++ b/acceptance/in_test.go
@@ -246,7 +246,7 @@ var _ = Describe("in", func() {
 
 			urlBytes, err := ioutil.ReadFile(filepath.Join(contentDir, "url"))
 			Expect(err).NotTo(HaveOccurred())
-			Expect(string(urlBytes)).ToNot(ContainSubstring("light"))
+			Expect(string(urlBytes)).NotTo(ContainSubstring("light"))
 		})
 	})
 

--- a/boshio/boshio.go
+++ b/boshio/boshio.go
@@ -15,10 +15,11 @@ import (
 )
 
 type Stemcell struct {
-	Name    string
-	Version string
-	Light   *Metadata `json:"light"`
-	Regular *Metadata `json:"regular"`
+	Name         string
+	Version      string
+	Light        *Metadata `json:"light"`
+	Regular      *Metadata `json:"regular"`
+	forceRegular bool
 }
 
 type Metadata struct {
@@ -42,7 +43,7 @@ type ranger interface {
 }
 
 func (s Stemcell) Details() Metadata {
-	if s.Light != nil {
+	if s.Light != nil && s.forceRegular == false {
 		return *s.Light
 	}
 
@@ -54,16 +55,16 @@ type Client struct {
 	Bar                  bar
 	Ranger               ranger
 	StemcellMetadataPath string
-	StemcellDownloadPath string
+	ForceRegular         bool
 }
 
-func NewClient(b bar, r ranger) *Client {
+func NewClient(b bar, r ranger, forceRegular bool) *Client {
 	return &Client{
 		Host:                 "https://bosh.io/",
 		Bar:                  b,
 		Ranger:               r,
 		StemcellMetadataPath: "api/v1/stemcells/%s",
-		StemcellDownloadPath: "d/stemcells/%s?v=%s",
+		ForceRegular:         forceRegular,
 	}
 }
 
@@ -90,24 +91,25 @@ func (c *Client) GetStemcells(name string) ([]Stemcell, error) {
 		return nil, err
 	}
 
-	return stemcells, nil
-}
-
-func (c *Client) FilterStemcells(version string, stemcells []Stemcell) (Stemcell, error) {
-	var stemcell Stemcell
-
-	for _, s := range stemcells {
-		if s.Version == version {
-			stemcell = s
-			break
+	if c.ForceRegular {
+		for i := 0; i < len(stemcells); i++ {
+			stemcells[i].forceRegular = true
 		}
 	}
 
-	if stemcell.Name == "" {
-		return Stemcell{}, fmt.Errorf("failed to find stemcell matching version: %q", version)
+	return stemcells, nil
+}
+
+func (c *Client) FilterStemcells(lambdaFilter func(Stemcell) bool, stemcells []Stemcell) []Stemcell {
+	var filteredStemcells []Stemcell
+
+	for _, s := range stemcells {
+		if lambdaFilter(s) {
+			filteredStemcells = append(filteredStemcells, s)
+		}
 	}
 
-	return stemcell, nil
+	return filteredStemcells
 }
 
 func (c *Client) WriteMetadata(stemcell Stemcell, metadataKey string, metadataFile io.Writer) error {
@@ -132,9 +134,18 @@ func (c *Client) WriteMetadata(stemcell Stemcell, metadataKey string, metadataFi
 	return nil
 }
 
+func (c *Client) SupportsLight(stemcells []Stemcell) bool {
+	for _, s := range stemcells {
+		if s.Light != nil {
+			return true
+		}
+	}
+	return false
+}
+
 func (c *Client) DownloadStemcell(stemcell Stemcell, location string, preserveFileName bool) error {
-	stemcellURL := c.Host + c.StemcellDownloadPath
-	resp, err := http.Head(fmt.Sprintf(stemcellURL, stemcell.Name, stemcell.Version))
+	stemcellURL := stemcell.Details().URL
+	resp, err := http.Head(stemcellURL)
 	if err != nil {
 		return err
 	}

--- a/boshio/boshio.go
+++ b/boshio/boshio.go
@@ -14,21 +14,6 @@ import (
 	"sync"
 )
 
-type Stemcell struct {
-	Name         string
-	Version      string
-	Light        *Metadata `json:"light"`
-	Regular      *Metadata `json:"regular"`
-	forceRegular bool
-}
-
-type Metadata struct {
-	URL  string
-	Size int64
-	MD5  string
-	SHA1 string
-}
-
 //go:generate counterfeiter -o ../fakes/bar.go --fake-name Bar . bar
 type bar interface {
 	SetTotal(contentLength int64)
@@ -40,14 +25,6 @@ type bar interface {
 //go:generate counterfeiter -o ../fakes/ranger.go --fake-name Ranger . ranger
 type ranger interface {
 	BuildRange(contentLength int64) ([]string, error)
-}
-
-func (s Stemcell) Details() Metadata {
-	if s.Light != nil && s.forceRegular == false {
-		return *s.Light
-	}
-
-	return *s.Regular
 }
 
 type Client struct {
@@ -68,7 +45,7 @@ func NewClient(b bar, r ranger, forceRegular bool) *Client {
 	}
 }
 
-func (c *Client) GetStemcells(name string) ([]Stemcell, error) {
+func (c *Client) GetStemcells(name string) (Stemcells, error) {
 	metadataURL := c.Host + c.StemcellMetadataPath
 
 	resp, err := http.Get(fmt.Sprintf(metadataURL, name))
@@ -93,23 +70,11 @@ func (c *Client) GetStemcells(name string) ([]Stemcell, error) {
 
 	if c.ForceRegular {
 		for i := 0; i < len(stemcells); i++ {
-			stemcells[i].forceRegular = true
+			stemcells[i].ForceRegular = true
 		}
 	}
 
 	return stemcells, nil
-}
-
-func (c *Client) FilterStemcells(lambdaFilter func(Stemcell) bool, stemcells []Stemcell) []Stemcell {
-	var filteredStemcells []Stemcell
-
-	for _, s := range stemcells {
-		if lambdaFilter(s) {
-			filteredStemcells = append(filteredStemcells, s)
-		}
-	}
-
-	return filteredStemcells
 }
 
 func (c *Client) WriteMetadata(stemcell Stemcell, metadataKey string, metadataFile io.Writer) error {
@@ -132,15 +97,6 @@ func (c *Client) WriteMetadata(stemcell Stemcell, metadataKey string, metadataFi
 	}
 
 	return nil
-}
-
-func (c *Client) SupportsLight(stemcells []Stemcell) bool {
-	for _, s := range stemcells {
-		if s.Light != nil {
-			return true
-		}
-	}
-	return false
 }
 
 func (c *Client) DownloadStemcell(stemcell Stemcell, location string, preserveFileName bool) error {

--- a/boshio/stemcells.go
+++ b/boshio/stemcells.go
@@ -1,0 +1,94 @@
+package boshio
+
+type Stemcell struct {
+	Name         string
+	Version      string
+	Light        *Metadata `json:"light"`
+	Regular      *Metadata `json:"regular"`
+	ForceRegular bool
+}
+
+type Metadata struct {
+	URL  string
+	Size int64
+	MD5  string
+	SHA1 string
+}
+
+func (s Stemcell) Details() Metadata {
+	if s.Light != nil && s.ForceRegular == false {
+		return *s.Light
+	}
+
+	return *s.Regular
+}
+
+type Stemcells []Stemcell
+
+func (s Stemcells) FindStemcellByVersion(version string) (Stemcell, bool) {
+	for _, stemcell := range s {
+		if stemcell.Version == version {
+			return stemcell, true
+		}
+	}
+	return Stemcell{}, false
+}
+
+func (s Stemcells) FilterByType() Stemcells {
+
+	if s.supportsLight() == false {
+		// all stemcells are Regular, no need to filter
+		return s
+	}
+
+	if s.forceRegular() {
+		return s.regularStemcellsOnly()
+	} else {
+		// The light stemcells might be published several hours after the regular versions
+		// The resource should wait until the corresponding light version is available to avoid
+		// caching a bulky regular stemcell
+		return s.lightStemcellsOnly()
+	}
+}
+
+func (s Stemcells) lightStemcellsOnly() Stemcells {
+	filterFunc := func(stemcell Stemcell) bool {
+		return stemcell.Light != nil
+	}
+	return s.filterStemcells(filterFunc)
+}
+
+func (s Stemcells) regularStemcellsOnly() Stemcells {
+	filterFunc := func(stemcell Stemcell) bool {
+		return stemcell.Regular != nil
+	}
+	return s.filterStemcells(filterFunc)
+}
+
+func (s Stemcells) filterStemcells(filterFunc func(Stemcell) bool) Stemcells {
+	filteredStemcells := Stemcells{}
+	for _, stemcell := range s {
+		if filterFunc(stemcell) {
+			filteredStemcells = append(filteredStemcells, stemcell)
+		}
+	}
+	return filteredStemcells
+}
+
+func (s Stemcells) forceRegular() bool {
+	for _, stemcell := range s {
+		if stemcell.ForceRegular {
+			return true
+		}
+	}
+	return false
+}
+
+func (s Stemcells) supportsLight() bool {
+	for _, stemcell := range s {
+		if stemcell.Light != nil {
+			return true
+		}
+	}
+	return false
+}

--- a/boshio/stemcells_test.go
+++ b/boshio/stemcells_test.go
@@ -1,0 +1,224 @@
+package boshio_test
+
+import (
+	"github.com/concourse/bosh-io-stemcell-resource/boshio"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Stemcells", func() {
+	Describe("Details", func() {
+		It("returns regular stemcell metadata", func() {
+			stemcell := boshio.Stemcell{
+				Regular: &boshio.Metadata{
+					URL:  "fake-url",
+					Size: 2000,
+					MD5:  "fake-md5",
+					SHA1: "fake-sha1",
+				},
+			}
+			metadata := stemcell.Details()
+			Expect(metadata).To(Equal(boshio.Metadata{
+				URL:  "fake-url",
+				Size: 2000,
+				MD5:  "fake-md5",
+				SHA1: "fake-sha1",
+			}))
+		})
+
+		It("returns light stemcell metadata", func() {
+			stemcell := boshio.Stemcell{
+				Light: &boshio.Metadata{
+					URL:  "fake-url",
+					Size: 2000,
+					MD5:  "fake-md5",
+					SHA1: "fake-sha1",
+				},
+			}
+			metadata := stemcell.Details()
+			Expect(metadata).To(Equal(boshio.Metadata{
+				URL:  "fake-url",
+				Size: 2000,
+				MD5:  "fake-md5",
+				SHA1: "fake-sha1",
+			}))
+		})
+
+		It("returns light stemcell metadata if both types are available", func() {
+			stemcell := boshio.Stemcell{
+				Light: &boshio.Metadata{
+					URL:  "fake-url-light",
+					Size: 2000,
+					MD5:  "fake-md5-light",
+					SHA1: "fake-sha1-light",
+				},
+				Regular: &boshio.Metadata{
+					URL:  "fake-url-regular",
+					Size: 2001,
+					MD5:  "fake-md5-regular",
+					SHA1: "fake-sha1-regular",
+				},
+			}
+			metadata := stemcell.Details()
+			Expect(metadata).To(Equal(boshio.Metadata{
+				URL:  "fake-url-light",
+				Size: 2000,
+				MD5:  "fake-md5-light",
+				SHA1: "fake-sha1-light",
+			}))
+		})
+
+		It("returns regular stemcell metadata if both types are available and force_regular is true", func() {
+			stemcell := boshio.Stemcell{
+				Light: &boshio.Metadata{
+					URL:  "fake-url-light",
+					Size: 2000,
+					MD5:  "fake-md5-light",
+					SHA1: "fake-sha1-light",
+				},
+				Regular: &boshio.Metadata{
+					URL:  "fake-url-regular",
+					Size: 2001,
+					MD5:  "fake-md5-regular",
+					SHA1: "fake-sha1-regular",
+				},
+				ForceRegular: true,
+			}
+			metadata := stemcell.Details()
+			Expect(metadata).To(Equal(boshio.Metadata{
+				URL:  "fake-url-regular",
+				Size: 2001,
+				MD5:  "fake-md5-regular",
+				SHA1: "fake-sha1-regular",
+			}))
+		})
+	})
+
+	Describe("FindStemcellByVersion", func() {
+		var stemcellList boshio.Stemcells
+
+		BeforeEach(func() {
+			stemcellList = boshio.Stemcells{
+				{
+					Name:    "some-stemcell",
+					Version: "111.1",
+				},
+				{
+					Name:    "some-other-stemcell",
+					Version: "111.2",
+				},
+				{
+					Name:    "some-other-stemcell",
+					Version: "2222",
+				},
+			}
+		})
+
+		It("returns the stemcell matching the criteria from the list", func() {
+			stemcell, ok := stemcellList.FindStemcellByVersion("111.2")
+			Expect(ok).To(BeTrue(), "Expected filter to find stemcell matching version 111.2, but it did not")
+			Expect(stemcell).To(Equal(boshio.Stemcell{
+				Name:    "some-other-stemcell",
+				Version: "111.2",
+			}))
+		})
+
+		Context("when the stemcell is not in the list", func() {
+			It("returns a zero-value", func() {
+				_, ok := stemcellList.FindStemcellByVersion("999.9")
+				Expect(ok).To(BeFalse(), "Expected filter not to find stemcell matching version 111.2, but it did")
+			})
+		})
+	})
+
+	Describe("FilterByType", func() {
+		var stemcellList boshio.Stemcells
+
+		Context("when only regular stemcells are available", func() {
+			BeforeEach(func() {
+				stemcellList = boshio.Stemcells{
+					{
+						Name:    "some-stemcell",
+						Regular: &boshio.Metadata{},
+					},
+					{
+						Name:    "some-other-stemcell",
+						Regular: &boshio.Metadata{},
+					},
+					{
+						Name:    "some-other-stemcell",
+						Regular: &boshio.Metadata{},
+					},
+				}
+			})
+
+			It("returns all regular stemcells", func() {
+				filteredStemcells := stemcellList.FilterByType()
+				Expect(filteredStemcells).To(Equal(stemcellList))
+			})
+		})
+
+		Context("when both regular and light stemcells are available", func() {
+			BeforeEach(func() {
+				stemcellList = boshio.Stemcells{
+					{
+						Name:    "some-stemcell",
+						Regular: &boshio.Metadata{},
+					},
+					{
+						Name:  "some-light-stemcell",
+						Light: &boshio.Metadata{},
+					},
+					{
+						Name:    "some-dual-stemcell",
+						Regular: &boshio.Metadata{},
+						Light:   &boshio.Metadata{},
+					},
+				}
+			})
+
+			It("returns only the light stemcells", func() {
+				filteredStemcells := stemcellList.FilterByType()
+				expectedStemcells := boshio.Stemcells{
+					{
+						Name:  "some-light-stemcell",
+						Light: &boshio.Metadata{},
+					},
+					{
+						Name:    "some-dual-stemcell",
+						Light:   &boshio.Metadata{},
+						Regular: &boshio.Metadata{},
+					},
+				}
+				Expect(filteredStemcells).To(Equal(expectedStemcells))
+			})
+
+			Context("when force_regular is true", func() {
+				BeforeEach(func() {
+					for i := range stemcellList {
+						stemcellList[i].ForceRegular = true
+					}
+				})
+
+				It("returns only the regular stemcells when force_regular is true", func() {
+					filteredStemcells := stemcellList.FilterByType()
+					expectedStemcells := boshio.Stemcells{
+						{
+							Name:         "some-stemcell",
+							Regular:      &boshio.Metadata{},
+							ForceRegular: true,
+						},
+						{
+							Name:         "some-dual-stemcell",
+							Light:        &boshio.Metadata{},
+							Regular:      &boshio.Metadata{},
+							ForceRegular: true,
+						},
+					}
+					Expect(filteredStemcells).To(Equal(expectedStemcells))
+				})
+			})
+		})
+	})
+})

--- a/cmd/check/main.go
+++ b/cmd/check/main.go
@@ -39,21 +39,7 @@ func main() {
 		log.Fatalf("failed getting stemcell: %s", err)
 	}
 
-	supportsLight := client.SupportsLight(stemcells)
-	if supportsLight {
-		if checkRequest.Source.ForceRegular {
-			regularFilter := func(stemcell boshio.Stemcell) bool {
-				return stemcell.Regular != nil
-			}
-			stemcells = client.FilterStemcells(regularFilter, stemcells)
-		} else {
-			lightFilter := func(stemcell boshio.Stemcell) bool {
-				return stemcell.Light != nil
-			}
-			stemcells = client.FilterStemcells(lightFilter, stemcells)
-		}
-	}
-
+	stemcells = stemcells.FilterByType()
 	filter := versions.NewFilter(checkRequest.Version.Version, stemcells)
 
 	filteredVersions, err := filter.Versions()

--- a/cmd/in/main.go
+++ b/cmd/in/main.go
@@ -63,14 +63,10 @@ func main() {
 		log.Fatalln(err)
 	}
 
-	filterFunc := func(stemcell boshio.Stemcell) bool {
-		return stemcell.Version == inRequest.Version.Version
-	}
-	matchingStemcells := client.FilterStemcells(filterFunc, stemcells)
-	if len(matchingStemcells) == 0 {
+	stemcell, ok := stemcells.FindStemcellByVersion(inRequest.Version.Version)
+	if !ok {
 		log.Fatalf("failed to find stemcell matching version: '%s'\n", inRequest.Version.Version)
 	}
-	stemcell := matchingStemcells[0]
 
 	dataLocations := []string{"version", "sha1", "url"}
 

--- a/versions/versions.go
+++ b/versions/versions.go
@@ -22,6 +22,10 @@ func NewFilter(initialVersion string, stemcells []boshio.Stemcell) Filter {
 }
 
 func (f Filter) Versions() ([]List, error) {
+	if len(f.stemcells) == 0 {
+		return []List{}, nil
+	}
+
 	var stemcellVersions []List
 
 	if f.initialVersion != "" {

--- a/versions/versions_test.go
+++ b/versions/versions_test.go
@@ -63,4 +63,38 @@ var _ = Describe("Versions", func() {
 			}))
 		})
 	})
+
+	Context("when passed an empty stemcell list and no initial version", func() {
+		var filter versions.Filter
+
+		BeforeEach(func() {
+			stemcells := []boshio.Stemcell{}
+
+			filter = versions.NewFilter("", stemcells)
+		})
+
+		It("returns an empty list", func() {
+			list, err := filter.Versions()
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(list).To(BeEmpty())
+		})
+	})
+
+	Context("when passed an empty stemcell list and an initial version", func() {
+		var filter versions.Filter
+
+		BeforeEach(func() {
+			stemcells := []boshio.Stemcell{}
+
+			filter = versions.NewFilter("3232.4", stemcells)
+		})
+
+		It("returns an empty list", func() {
+			list, err := filter.Versions()
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(list).To(BeEmpty())
+		})
+	})
 })


### PR DESCRIPTION
- If `force_regular` is true (default false), the resource will only check/get
  stemcells with that have a regular (i.e. heavy) stemcell URL
- Handles timing issues in stemcell publishing process where a heavy stemcell appears on
  bosh.io before the corresponding light stemcell
  - Unless `force_regular` is true, `check` will now ignore new versions that only have a regular
    stemcell and will only trigger once the light version appears for IaaSes that support light stemcells
  - It would be bad on AWS if Concourse triggered on a heavy stemcell instead of waiting for the light
    stemcell

[#129544375](https://www.pivotaltracker.com/story/show/129544375)
