### PR TITLE
Add version_family flag to lock to a given stemcell "line"

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,11 @@ resources:
 ## Source Configuration
 
 * `name`: *Required.* The name of the stemcell.
-* `force_regular`: *Optional.* Default `false`. By default, the resource will always download light stemcells for IaaSes
-  that support light stemcells. If `force_regular` is `true`, the resource will ignore light stemcells and always
-  download regular stemcells.
+* `version_family`: *Optional.* A semantic version used to narrow the returned versions, typically used to fetch hotfixes on older stemcells.
+  For example, a `version_family` of `3262` would match `3262`, `3262.1`, and `3262.1.1`, but not `3263`.
+  A `version_family` of `3262.1` would match `3262.1` and `3262.1.1`, but not `3262.2`.
+* `force_regular`: *Optional.* Default `false`. By default, the resource will always download light stemcells for IaaSes that support light stemcells.
+  If `force_regular` is `true`, the resource will ignore light stemcells and always download regular stemcells.
 
 ## Behavior
 

--- a/README.md
+++ b/README.md
@@ -15,9 +15,13 @@ resources:
 ## Source Configuration
 
 * `name`: *Required.* The name of the stemcell.
-* `version_family`: *Optional.* A semantic version used to narrow the returned versions, typically used to fetch hotfixes on older stemcells.
-  For example, a `version_family` of `3262` would match `3262`, `3262.1`, and `3262.1.1`, but not `3263`.
-  A `version_family` of `3262.1` would match `3262.1` and `3262.1.1`, but not `3262.2`.
+
+* `version_family`: *Optional.* Default `latest`. A semantic version used to
+narrow the returned versions, typically used to fetch hotfixes on older
+stemcells. For example, a `version_family` of `3262.latest` would match `3262`,
+`3262.1`, and `3262.1.1`, but not `3263`. A `version_family` of `3262.1.latest`
+would match `3262.1` and `3262.1.1`, but not `3262.2`.
+
 * `force_regular`: *Optional.* Default `false`. By default, the resource will always download light stemcells for IaaSes that support light stemcells.
   If `force_regular` is `true`, the resource will ignore light stemcells and always download regular stemcells.
 

--- a/acceptance/check_test.go
+++ b/acceptance/check_test.go
@@ -20,6 +20,17 @@ const noVersionRequest = `
 	}
 }`
 
+const versionFamilyRequest = `
+{
+	"source": {
+		"name": "bosh-aws-xen-hvm-ubuntu-trusty-go_agent",
+		"version_family": "3262.4"
+	},
+	"version": {
+		"version":"3262"
+	}
+}`
+
 const specificVersionRequest = `
 {
 	"source": {
@@ -72,6 +83,37 @@ var _ = Describe("check", func() {
 			Expect(result[0]["version"]).NotTo(BeEmpty())
 			Expect(result[0]["version"]).NotTo(Equal("3262.7"))
 			Expect(result[0]["version"]).NotTo(Equal("3262.5"))
+		})
+	})
+
+	Context("when a version_family is specified", func() {
+		var command *exec.Cmd
+
+		BeforeEach(func() {
+			command = exec.Command(boshioCheck)
+			command.Stdin = bytes.NewBufferString(versionFamilyRequest)
+		})
+
+		It("returns only versions that match the given semver", func() {
+			session, err := gexec.Start(command, GinkgoWriter, GinkgoWriter)
+			Expect(err).NotTo(HaveOccurred())
+
+			<-session.Exited
+			Expect(session.ExitCode()).To(Equal(0))
+
+			result := []stemcellVersion{}
+			err = json.Unmarshal(session.Out.Contents(), &result)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(result).To(ContainElement(stemcellVersion{
+				"version": "3262.4",
+			}))
+			Expect(result).To(ContainElement(stemcellVersion{
+				"version": "3262.4.1",
+			}))
+			Expect(result).NotTo(ContainElement(stemcellVersion{
+				"version": "3262.5",
+			}))
 		})
 	})
 

--- a/cmd/check/main.go
+++ b/cmd/check/main.go
@@ -14,8 +14,9 @@ import (
 
 type concourseCheck struct {
 	Source struct {
-		Name         string `json:"name"`
-		ForceRegular bool   `json:"force_regular"`
+		Name          string `json:"name"`
+		ForceRegular  bool   `json:"force_regular"`
+		VersionFamily string `json:"version_family"`
 	}
 	Version struct {
 		Version string `json:"version"`
@@ -43,7 +44,11 @@ func main() {
 	}
 
 	stemcells = stemcells.FilterByType()
-	filter := versions.NewFilter(checkRequest.Version.Version, stemcells)
+	filter := versions.NewFilter(
+		checkRequest.Version.Version,
+		stemcells,
+		checkRequest.Source.VersionFamily,
+	)
 
 	filteredVersions, err := filter.Versions()
 	if err != nil {

--- a/versions/versions.go
+++ b/versions/versions.go
@@ -31,7 +31,7 @@ func (f Filter) Versions() (StemcellVersions, error) {
 	}
 
 	stemcellVersions := f.mapStemcellsToVersions(f.stemcells)
-	if len(f.versionFamily) > 0 {
+	if len(f.versionFamily) > 0 && f.versionFamily != "latest" {
 		var err error
 		stemcellVersions, err = f.filterStemcellsByVersionFamily(stemcellVersions)
 		if err != nil {
@@ -61,13 +61,18 @@ func (f Filter) mapStemcellsToVersions(stemcells []boshio.Stemcell) StemcellVers
 }
 
 func (f Filter) filterStemcellsByVersionFamily(stemcells StemcellVersions) (StemcellVersions, error) {
-	parsedVersion, err := semver.ParseTolerant(f.versionFamily)
+	familyVersion := f.versionFamily
+	if strings.Contains(f.versionFamily, ".latest") {
+		familyVersion = f.versionFamily[0 : len(f.versionFamily)-len(".latest")]
+	}
+
+	parsedVersion, err := semver.ParseTolerant(familyVersion)
 	if err != nil {
 		return StemcellVersions{}, err
 	}
 
 	parsedVersionCeiling := parsedVersion
-	numberOfSignificantDigits := strings.Count(f.versionFamily, ".") + 1
+	numberOfSignificantDigits := strings.Count(familyVersion, ".") + 1
 	switch numberOfSignificantDigits {
 	case 1:
 		parsedVersionCeiling.Major += 1


### PR DESCRIPTION
- Useful for locking to a given hotfix line of stemcells

Signed-off-by: Brian Cunnie bcunnie@pivotal.io

[#133033179](https://www.pivotaltracker.com/story/show/133033179)
