### PR TITLE
Tweak retry logic to be more robust to poor network connection

### DIFF
--- a/boshio/boshio_test.go
+++ b/boshio/boshio_test.go
@@ -37,7 +37,7 @@ var _ = Describe("Boshio", func() {
 		ranger = &fakes.Ranger{}
 		bar = &fakes.Bar{}
 		forceRegular = false
-		httpClient = boshio.HTTPClient{Host: boshioServer.URL(), Wait: 800 * time.Millisecond, Client: http.DefaultClient}
+		httpClient = boshio.NewHTTPClient(boshioServer.URL(), 800*time.Millisecond)
 		client = boshio.NewClient(httpClient, bar, ranger, forceRegular)
 	})
 

--- a/boshio/http_client.go
+++ b/boshio/http_client.go
@@ -9,13 +9,24 @@ import (
 )
 
 type HTTPClient struct {
-	Host   string
-	Wait   time.Duration
-	Client *http.Client
+	host    string
+	timeout time.Duration
+	wait    time.Duration
+	client  *http.Client
+}
+
+func NewHTTPClient(host string, timeout time.Duration) HTTPClient {
+	return HTTPClient{
+		host: host,
+		wait: 1 * time.Second,
+		client: &http.Client{
+			Timeout: timeout,
+		},
+	}
 }
 
 func (h HTTPClient) Do(req *http.Request) (*http.Response, error) {
-	root, err := url.Parse(h.Host)
+	root, err := url.Parse(h.host)
 	if err != nil {
 		return &http.Response{}, fmt.Errorf("failed to parse URL: %s", err)
 	}
@@ -28,10 +39,10 @@ func (h HTTPClient) Do(req *http.Request) (*http.Response, error) {
 	var resp *http.Response
 
 	for {
-		resp, err = h.Client.Do(req)
+		resp, err = h.client.Do(req)
 		if netErr, ok := err.(net.Error); ok {
 			if netErr.Temporary() {
-				time.Sleep(h.Wait)
+				time.Sleep(h.wait)
 				continue
 			}
 			break

--- a/boshio/http_client_test.go
+++ b/boshio/http_client_test.go
@@ -1,7 +1,6 @@
 package boshio_test
 
 import (
-	"errors"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
@@ -13,31 +12,6 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
-
-type tempError struct {
-	error
-}
-
-func (te tempError) Temporary() bool {
-	return true
-}
-
-func (te tempError) Timeout() bool {
-	return false
-}
-
-type fakeTransport struct {
-	count int
-}
-
-func (f *fakeTransport) RoundTrip(req *http.Request) (*http.Response, error) {
-	if f.count != 1 {
-		f.count++
-		return nil, tempError{errors.New("boom")}
-	}
-
-	return &http.Response{StatusCode: http.StatusOK}, nil
-}
 
 var _ = Describe("HTTPClient", func() {
 	Describe("Do", func() {
@@ -55,7 +29,7 @@ var _ = Describe("HTTPClient", func() {
 				Expect(err).NotTo(HaveOccurred())
 			}))
 
-			client := boshio.HTTPClient{Host: server.URL, Wait: 500 * time.Millisecond, Client: http.DefaultClient}
+			client := boshio.NewHTTPClient(server.URL, 500*time.Millisecond)
 
 			request, err := http.NewRequest("POST", "/more/path", strings.NewReader(`{"test": "something"}`))
 			Expect(err).NotTo(HaveOccurred())
@@ -81,7 +55,7 @@ var _ = Describe("HTTPClient", func() {
 					w.WriteHeader(http.StatusTeapot)
 				}))
 
-				client := boshio.HTTPClient{Host: stemcells.URL, Wait: 500 * time.Millisecond, Client: http.DefaultClient}
+				client := boshio.NewHTTPClient(stemcells.URL, 500*time.Millisecond)
 
 				request, err := http.NewRequest("POST", amazon.URL, strings.NewReader(`{"test": "something"}`))
 				Expect(err).NotTo(HaveOccurred())
@@ -95,7 +69,18 @@ var _ = Describe("HTTPClient", func() {
 
 		Context("when the request has a temporary error", func() {
 			It("retries the request", func() {
-				client := boshio.HTTPClient{Host: "http://www.example.com", Wait: 100 * time.Millisecond, Client: &http.Client{Transport: &fakeTransport{}}}
+				var numRequest int
+				server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+					switch numRequest {
+					case 0:
+						time.Sleep(500 * time.Millisecond)
+					case 1:
+						time.Sleep(50 * time.Millisecond)
+					}
+					numRequest++
+				}))
+
+				client := boshio.NewHTTPClient(server.URL, 100*time.Millisecond)
 
 				request, err := http.NewRequest("GET", "/different/path", nil)
 				Expect(err).NotTo(HaveOccurred())
@@ -110,7 +95,7 @@ var _ = Describe("HTTPClient", func() {
 		Context("when an error occurs", func() {
 			Context("when the host cannot be parsed", func() {
 				It("returns an error", func() {
-					client := boshio.HTTPClient{Host: "%%%%%%", Wait: 100 * time.Millisecond, Client: http.DefaultClient}
+					client := boshio.NewHTTPClient("%%%%%%", 100*time.Millisecond)
 
 					_, err := client.Do(&http.Request{})
 					Expect(err).To(MatchError(ContainSubstring("failed to parse URL")))

--- a/cmd/check/main.go
+++ b/cmd/check/main.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
-	"net/http"
 	"os"
 	"time"
 
@@ -29,11 +28,7 @@ func main() {
 		log.Fatalf("failed reading json: %s", err)
 	}
 
-	httpClient := boshio.HTTPClient{
-		Host:   "https://bosh.io",
-		Wait:   800 * time.Millisecond,
-		Client: http.DefaultClient,
-	}
+	httpClient := boshio.NewHTTPClient("https://bosh.io", 5*time.Minute)
 
 	client := boshio.NewClient(httpClient, nil, nil, checkRequest.Source.ForceRegular)
 	stemcells, err := client.GetStemcells(checkRequest.Source.Name)

--- a/cmd/in/main.go
+++ b/cmd/in/main.go
@@ -51,7 +51,7 @@ func main() {
 
 	location := os.Args[1]
 
-	httpClient := boshio.NewHTTPClient("https://bosh.io", 5*time.Minute)
+	httpClient := boshio.NewHTTPClient("https://bosh.io", 800*time.Millisecond)
 
 	client := boshio.NewClient(httpClient, progress.NewBar(), content.NewRanger(routines), inRequest.Source.ForceRegular)
 

--- a/cmd/in/main.go
+++ b/cmd/in/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"encoding/json"
 	"log"
-	"net/http"
 	"os"
 	"path/filepath"
 	"time"
@@ -52,11 +51,7 @@ func main() {
 
 	location := os.Args[1]
 
-	httpClient := boshio.HTTPClient{
-		Host:   "https://bosh.io",
-		Wait:   800 * time.Millisecond,
-		Client: http.DefaultClient,
-	}
+	httpClient := boshio.NewHTTPClient("https://bosh.io", 5*time.Minute)
 
 	client := boshio.NewClient(httpClient, progress.NewBar(), content.NewRanger(routines), inRequest.Source.ForceRegular)
 


### PR DESCRIPTION
Summary: We have an external Concourse worker with a **very** poor internet connection. This PR makes a few tweaks to HTTP retries and underlying TCP settings to make downloads more reliable in this environment.

- Revert removal of HTTPClient wrapper
  - We needed to change some default HTTP client settings
  - We were still able to use a fake client to simulate a retryable error
- Retry on "connection refused"
  - Downloading from S3 into our worker saw this error frequently
- Bumps TLS Handshake timeout
  - We saw this timeout several times on our worker (although this error will be retried regardless)
- Disable TCP keepalive messages and TCP connection re-use
  - these settings were recommended by BOSH team as they saw issues
    using these settings on various infrastructures
  - Although not conclusive, disabling these settings did seem to drop
    our error rate in our environment
- Refactors out `goto` call

[#133704741](https://www.pivotaltracker.com/story/show/133704741)

Signed-off-by: Chris Hajas <chajas@pivotal.io>
