### PR TITLE
Retrieve all stemcells on check

### DIFF
--- a/boshio/boshio.go
+++ b/boshio/boshio.go
@@ -48,7 +48,7 @@ func NewClient(httpClient httpClient, b bar, r ranger, forceRegular bool) *Clien
 		httpClient:           httpClient,
 		Bar:                  b,
 		Ranger:               r,
-		StemcellMetadataPath: "/api/v1/stemcells/%s",
+		StemcellMetadataPath: "/api/v1/stemcells/%s?all=1",
 		ForceRegular:         forceRegular,
 	}
 }


### PR DESCRIPTION
- bosh.io only returns the most recent 40 stemcells unless URL contains
  `?all=1`
- This can be used for pulling older hotfix stemcells
  - E.g. bosh still produces hotfixes for 3151 stemcells

[#133033179](https://www.pivotaltracker.com/story/show/133033179)