### PR TITLE
Revert "switch to ubuntu:bionic base image"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM concourse/golang-builder as builder
+FROM golang:alpine as builder
 COPY . /go/src/github.com/concourse/bosh-io-stemcell-resource
 ENV CGO_ENABLED 0
 ENV GOPATH /go/src/github.com/concourse/bosh-io-stemcell-resource/Godeps/_workspace:${GOPATH}
@@ -10,12 +10,8 @@ RUN set -e; for pkg in $(go list ./...); do \
 		go test -o "/tests/$(basename $pkg).test" -c $pkg; \
 	done
 
-FROM ubuntu:bionic AS resource
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    tzdata \
-    ca-certificates \
-  && rm -rf /var/lib/apt/lists/*
-
+FROM alpine:edge AS resource
+RUN apk add --update bash tzdata ca-certificates
 COPY --from=builder /assets /opt/resource
 
 FROM resource AS tests


### PR DESCRIPTION
Reverts concourse/bosh-io-stemcell-resource#21

The switch to `ubuntu:bionic` has been pushed back to after the Concourse 5.0.0 release. 
For now we will keep the change in a branch and open a new PR when we are ready to ship the switch