### PR TITLE
Add force_light option to prevent regular stemcells from being used

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,11 @@ would match `3262.1` and `3262.1.1`, but not `3262.2`.
 * `force_regular`: *Optional.* Default `false`. By default, the resource will always download light stemcells for IaaSes that support light stemcells.
   If `force_regular` is `true`, the resource will ignore light stemcells and always download regular stemcells.
 
+* `force_light`: *Optional.* Default `false`. By default, the resource will always download light stemcells for IaaSes
+  that support light stemcells. If `force_light` is `true`, the resource will ignore regular stemcells and always
+  download light stemcells. Without `force_light` set it is possible for a `check` to return a regular stemcell in
+  cases where the regular has been published, but the light version is not yet published.
+
 ## Behavior
 
 ### `check`: Check for new versions of the stemcell.

--- a/acceptance/check_test.go
+++ b/acceptance/check_test.go
@@ -62,14 +62,6 @@ const oldVersionRequest = `
 	}
 }`
 
-const lightOnlyForceRegularRequest = `
-{
-	"source": {
-		"name": "bosh-aws-xen-hvm-ubuntu-trusty-go_agent",
-		"force_regular": true
-	}
-}`
-
 const bothTypesForceRegularRequest = `
 {
 	"source": {
@@ -271,29 +263,6 @@ var _ = Describe("check", func() {
 
 				Expect(result).To(HaveLen(1))
 				Expect(result[0]["version"]).NotTo(BeEmpty())
-			})
-		})
-
-		XContext("and only light stemcell versions are available", func() {
-			var command *exec.Cmd
-
-			BeforeEach(func() {
-				command = exec.Command(boshioCheck)
-				command.Stdin = bytes.NewBufferString(lightOnlyForceRegularRequest)
-			})
-
-			It("returns an empty version set", func() {
-				session, err := gexec.Start(command, GinkgoWriter, GinkgoWriter)
-				Expect(err).NotTo(HaveOccurred())
-
-				<-session.Exited
-				Expect(session.ExitCode()).To(Equal(0))
-
-				result := []stemcellVersion{}
-				err = json.Unmarshal(session.Out.Contents(), &result)
-				Expect(err).NotTo(HaveOccurred())
-
-				Expect(result).To(HaveLen(0))
 			})
 		})
 	})

--- a/boshio/boshio.go
+++ b/boshio/boshio.go
@@ -41,15 +41,17 @@ type Client struct {
 	Ranger               ranger
 	StemcellMetadataPath string
 	ForceRegular         bool
+	ForceLight           bool
 }
 
-func NewClient(httpClient httpClient, b bar, r ranger, forceRegular bool) *Client {
+func NewClient(httpClient httpClient, b bar, r ranger, forceRegular bool, forceLight bool) *Client {
 	return &Client{
 		httpClient:           httpClient,
 		Bar:                  b,
 		Ranger:               r,
 		StemcellMetadataPath: "/api/v1/stemcells/%s?all=1",
 		ForceRegular:         forceRegular,
+		ForceLight:           forceLight,
 	}
 }
 
@@ -79,10 +81,9 @@ func (c *Client) GetStemcells(name string) (Stemcells, error) {
 		return nil, err
 	}
 
-	if c.ForceRegular {
-		for i := 0; i < len(stemcells); i++ {
-			stemcells[i].ForceRegular = true
-		}
+	for i := 0; i < len(stemcells); i++ {
+		stemcells[i].ForceRegular = c.ForceRegular
+		stemcells[i].ForceLight = c.ForceLight
 	}
 
 	return stemcells, nil

--- a/boshio/boshio_test.go
+++ b/boshio/boshio_test.go
@@ -31,14 +31,16 @@ var _ = Describe("Boshio", func() {
 		ranger       *fakes.Ranger
 		bar          *fakes.Bar
 		forceRegular bool
+		forceLight bool
 	)
 
 	BeforeEach(func() {
 		ranger = &fakes.Ranger{}
 		bar = &fakes.Bar{}
 		forceRegular = false
+		forceLight = false
 		httpClient = boshio.NewHTTPClient(boshioServer.URL(), 800*time.Millisecond)
-		client = boshio.NewClient(httpClient, bar, ranger, forceRegular)
+		client = boshio.NewClient(httpClient, bar, ranger, forceRegular, forceLight)
 	})
 
 	Describe("GetStemcells", func() {
@@ -259,7 +261,7 @@ var _ = Describe("Boshio", func() {
 
 				httpErrors = []error{nil, nil, nil}
 
-				client = boshio.NewClient(httpClient, bar, ranger, forceRegular)
+				client = boshio.NewClient(httpClient, bar, ranger, forceRegular, forceLight)
 
 				location, err := ioutil.TempDir("", "")
 				Expect(err).NotTo(HaveOccurred())

--- a/boshio/stemcells.go
+++ b/boshio/stemcells.go
@@ -6,6 +6,7 @@ type Stemcell struct {
 	Light        *Metadata `json:"light"`
 	Regular      *Metadata `json:"regular"`
 	ForceRegular bool
+	ForceLight   bool
 }
 
 type Metadata struct {
@@ -36,18 +37,14 @@ func (s Stemcells) FindStemcellByVersion(version string) (Stemcell, bool) {
 }
 
 func (s Stemcells) FilterByType() Stemcells {
-
-	if s.supportsLight() == false {
-		// all stemcells are Regular, no need to filter
-		return s
-	}
-
 	if s.forceRegular() {
 		return s.regularStemcellsOnly()
+	} else if s.forceLight()  {
+		return s.lightStemcellsOnly()
+	} else if s.supportsLight() == false {
+		// all stemcells are Regular, no need to filter
+		return s
 	} else {
-		// The light stemcells might be published several hours after the regular versions
-		// The resource should wait until the corresponding light version is available to avoid
-		// caching a bulky regular stemcell
 		return s.lightStemcellsOnly()
 	}
 }
@@ -79,6 +76,15 @@ func (s Stemcells) filterStemcells(filterFunc func(Stemcell) bool) Stemcells {
 func (s Stemcells) forceRegular() bool {
 	for _, stemcell := range s {
 		if stemcell.ForceRegular {
+			return true
+		}
+	}
+	return false
+}
+
+func (s Stemcells) forceLight() bool {
+	for _, stemcell := range s {
+		if stemcell.ForceLight {
 			return true
 		}
 	}

--- a/boshio/stemcells_test.go
+++ b/boshio/stemcells_test.go
@@ -240,5 +240,41 @@ var _ = Describe("Stemcells", func() {
 				})
 			})
 		})
+
+		Context("when only regular stemcells are available", func() {
+			BeforeEach(func() {
+				stemcellList = boshio.Stemcells{
+					{
+						Name:    "some-stemcell",
+						Regular: &boshio.Metadata{},
+					},
+				}
+			})
+
+			It("returns all the stemcells", func() {
+				filteredStemcells := stemcellList.FilterByType()
+				expectedStemcells := boshio.Stemcells{
+					{
+						Name:    "some-stemcell",
+						Regular: &boshio.Metadata{},
+					},
+				}
+				Expect(filteredStemcells).To(Equal(expectedStemcells))
+			})
+
+			Context("when force_light is true", func() {
+				BeforeEach(func() {
+					for i := range stemcellList {
+						stemcellList[i].ForceLight = true
+					}
+				})
+
+				It("returns no stemcells", func() {
+					filteredStemcells := stemcellList.FilterByType()
+					expectedStemcells := boshio.Stemcells{}
+					Expect(filteredStemcells).To(Equal(expectedStemcells))
+				})
+			})
+		})
 	})
 })

--- a/cmd/check/main.go
+++ b/cmd/check/main.go
@@ -15,6 +15,7 @@ type concourseCheck struct {
 	Source struct {
 		Name          string `json:"name"`
 		ForceRegular  bool   `json:"force_regular"`
+		ForceLight  bool     `json:"force_light"`
 		VersionFamily string `json:"version_family"`
 	}
 	Version struct {
@@ -31,7 +32,7 @@ func main() {
 
 	httpClient := boshio.NewHTTPClient("https://bosh.io", 5*time.Minute)
 
-	client := boshio.NewClient(httpClient, nil, nil, checkRequest.Source.ForceRegular)
+	client := boshio.NewClient(httpClient, nil, nil, checkRequest.Source.ForceRegular, checkRequest.Source.ForceLight)
 	stemcells, err := client.GetStemcells(checkRequest.Source.Name)
 	if err != nil {
 		log.Fatalf("failed getting stemcell: %s", err)

--- a/cmd/in/main.go
+++ b/cmd/in/main.go
@@ -18,6 +18,7 @@ type concourseInRequest struct {
 	Source struct {
 		Name         string `json:"name"`
 		ForceRegular bool   `json:"force_regular"`
+		ForceLight   bool   `json:"force_light"`
 	} `json:"source"`
 	Params struct {
 		Tarball          bool `json:"tarball"`
@@ -53,7 +54,7 @@ func main() {
 
 	httpClient := boshio.NewHTTPClient("https://bosh.io", 800*time.Millisecond)
 
-	client := boshio.NewClient(httpClient, progress.NewBar(), content.NewRanger(routines), inRequest.Source.ForceRegular)
+	client := boshio.NewClient(httpClient, progress.NewBar(), content.NewRanger(routines), inRequest.Source.ForceRegular, inRequest.Source.ForceLight)
 
 	stemcells, err := client.GetStemcells(inRequest.Source.Name)
 	if err != nil {


### PR DESCRIPTION
The current behavior of defaulting to light stemcells and returning regular stemcells only if NO light stemcells seems correct but fails when doing incremental checks.

The current behavior fails when doing a check and a single new regular stemcell has been published, but the light version has not. In that case the resource will see that there are no light stemcells in the returned list, and return the regular version.

This can lead to consuming regular stemcells when it's important that only light stemcells are used.