### PR TITLE
Updating stemcell version in test fixtures

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,14 +2,14 @@
 
 Tracks the versions of a stemcell on [bosh.io](https://bosh.io).
 
-For example, to automatically consume `bosh-aws-xen-ubuntu-trusty-go_agent`:
+For example, to automatically consume `bosh-aws-xen-hvm-ubuntu-trusty-go_agent`:
 
 ```yaml
 resources:
 - name: aws-stemcell
   type: bosh-io-stemcell
   source:
-    name: bosh-aws-xen-ubuntu-trusty-go_agent
+    name: bosh-aws-xen-hvm-ubuntu-trusty-go_agent
 ```
 
 ## Source Configuration

--- a/acceptance/check_test.go
+++ b/acceptance/check_test.go
@@ -73,7 +73,7 @@ const lightOnlyForceRegularRequest = `
 const bothTypesForceRegularRequest = `
 {
 	"source": {
-		"name": "bosh-aws-xen-ubuntu-trusty-go_agent",
+		"name": "bosh-aws-xen-hvm-ubuntu-trusty-go_agent",
 		"force_regular": true
 	}
 }`

--- a/acceptance/in_test.go
+++ b/acceptance/in_test.go
@@ -200,16 +200,15 @@ var _ = Describe("in", func() {
 			Expect(err).NotTo(HaveOccurred())
 		})
 
-		It("downloads the light stemcell with metadata", func() {
+		FIt("downloads the light stemcell with metadata", func() {
+			fmt.Println("boshioIn---------------------")
+			fmt.Println(boshioIn)
+			fmt.Println("---------------------")
+
 			session, err := gexec.Start(command, GinkgoWriter, GinkgoWriter)
 			Expect(err).NotTo(HaveOccurred())
 
 			<-session.Exited
-			fmt.Println("---------------------------")
-			fmt.Println(string(session.Err.Contents()))
-			fmt.Println("-------------")
-			fmt.Println(string(session.Out.Contents()))
-			fmt.Println("---------------------------")
 			Expect(session.ExitCode()).To(Equal(0))
 
 			tarballBytes, err := ioutil.ReadFile(filepath.Join(contentDir, "stemcell.tgz"))

--- a/acceptance/in_test.go
+++ b/acceptance/in_test.go
@@ -115,7 +115,7 @@ var _ = Describe("in", func() {
 
 				<-session.Exited
 				Expect(session.ExitCode()).To(Equal(0))
-				Expect(session.Out).To(gbytes.Say(`{"version":{"version":"3586.100"},"metadata":[{"name":"url","value":"https://s3.amazonaws.com/bosh-aws-light-stemcells/3586.100/light-bosh-stemcell-3586.100-aws-xen-hvm-ubuntu-trusty-go_agent.tgz"},{"name":"sha1","value":"b78c60c1bc60d91d798bccc098180167c3c794fe"},{"name":"sha256","value":"e03853323c7f5636e78a6322935274ba9acbcd525e967f5e609c3a3fcf3e7ab9"}]}`))
+				Expect(session.Out).To(gbytes.Say(`{"version":{"version":"3586.100"},"metadata":\[{"name":"url","value":"https://s3.amazonaws.com/bosh-aws-light-stemcells/3586.100/light-bosh-stemcell-3586.100-aws-xen-hvm-ubuntu-trusty-go_agent.tgz"},{"name":"sha1","value":"b78c60c1bc60d91d798bccc098180167c3c794fe"},{"name":"sha256","value":"e03853323c7f5636e78a6322935274ba9acbcd525e967f5e609c3a3fcf3e7ab9"}\]}`))
 
 				version, err := ioutil.ReadFile(filepath.Join(contentDir, "version"))
 				Expect(err).NotTo(HaveOccurred())
@@ -175,7 +175,7 @@ var _ = Describe("in", func() {
 				Expect(err).NotTo(HaveOccurred())
 				Expect(string(sha256Checksum)).To(Equal(fmt.Sprintf("%x", sha256.Sum256(tarballBytes))))
 				
-				Expect(session.Out).To(gbytes.Say(fmt.Sprintf(`{"version":{"version":"3586.100"},"metadata":[{"name":"url","value":"https://s3.amazonaws.com/bosh-core-stemcells/3586.100/bosh-stemcell-3586.100-azure-hyperv-ubuntu-trusty-go_agent.tgz"},{"name":"sha1","value":"%s"},{"name":"sha256","value":"%s"}]}`, string(sha1Checksum), string(sha256Checksum))))
+				Expect(session.Out).To(gbytes.Say(fmt.Sprintf(`{"version":{"version":"3586.100"},"metadata":\[{"name":"url","value":"https://s3.amazonaws.com/bosh-core-stemcells/3586.100/bosh-stemcell-3586.100-azure-hyperv-ubuntu-trusty-go_agent.tgz"},{"name":"sha1","value":"%s"},{"name":"sha256","value":"%s"}\]}`, string(sha1Checksum), string(sha256Checksum))))
 			})
 		})
 	})
@@ -307,7 +307,7 @@ var _ = Describe("in", func() {
 				Expect(err).NotTo(HaveOccurred())
 				Expect(string(sha256Checksum)).To(Equal(fmt.Sprintf("%x", sha256.Sum256(tarballBytes))))
 				
-				Expect(session.Out).To(gbytes.Say(fmt.Sprintf(`{"version":{"version":"3586.100"},"metadata":[{"name":"url","value":"https://s3.amazonaws.com/bosh-aws-light-stemcells/3586.100/light-bosh-stemcell-3586.100-aws-xen-hvm-ubuntu-trusty-go_agent.tgz"},{"name":"sha1","value":"%s"},{"name":"sha256","value":"%s"}]}`, string(sha1Checksum), string(sha256Checksum))))
+				Expect(session.Out).To(gbytes.Say(fmt.Sprintf(`{"version":{"version":"3586.100"},"metadata":\[{"name":"url","value":"https://s3.amazonaws.com/bosh-aws-light-stemcells/3586.100/light-bosh-stemcell-3586.100-aws-xen-hvm-ubuntu-trusty-go_agent.tgz"},{"name":"sha1","value":"%s"},{"name":"sha256","value":"%s"}\]}`, string(sha1Checksum), string(sha256Checksum))))
 			})
 		})
 	})

--- a/acceptance/in_test.go
+++ b/acceptance/in_test.go
@@ -206,8 +206,8 @@ var _ = Describe("in", func() {
 
 			<-session.Exited
 			fmt.Println("---------------------------")
-			fmt.Println(session.Err)
-			fmt.Println(session.Out)
+			fmt.Printf("Error: %v\n", session.Err)
+			fmt.Printf("Output: %v\n", session.Out)
 			fmt.Println("---------------------------")
 			Expect(session.ExitCode()).To(Equal(0))
 

--- a/acceptance/in_test.go
+++ b/acceptance/in_test.go
@@ -115,7 +115,7 @@ var _ = Describe("in", func() {
 
 				<-session.Exited
 				Expect(session.ExitCode()).To(Equal(0))
-				Expect(session.Out).To(gbytes.Say(`{"version":{"version":"3586.100"},"metadata":\[{"name":"url","value":"https://s3.amazonaws.com/bosh-aws-light-stemcells/3586.100/light-bosh-stemcell-3586.100-aws-xen-hvm-ubuntu-trusty-go_agent.tgz"},{"name":"sha1","value":"b78c60c1bc60d91d798bccc098180167c3c794fe"},{"name":"sha256","value":"e03853323c7f5636e78a6322935274ba9acbcd525e967f5e609c3a3fcf3e7ab9"}\]}`))
+				Expect(session.Out).To(gbytes.Say(`{"version":{"version":"3586.100"},"metadata":[{"name":"url","value":"https://s3.amazonaws.com/bosh-aws-light-stemcells/3586.100/light-bosh-stemcell-3586.100-aws-xen-hvm-ubuntu-trusty-go_agent.tgz"},{"name":"sha1","value":"b78c60c1bc60d91d798bccc098180167c3c794fe"},{"name":"sha256","value":"e03853323c7f5636e78a6322935274ba9acbcd525e967f5e609c3a3fcf3e7ab9"}]}`))
 
 				version, err := ioutil.ReadFile(filepath.Join(contentDir, "version"))
 				Expect(err).NotTo(HaveOccurred())
@@ -175,7 +175,7 @@ var _ = Describe("in", func() {
 				Expect(err).NotTo(HaveOccurred())
 				Expect(string(sha256Checksum)).To(Equal(fmt.Sprintf("%x", sha256.Sum256(tarballBytes))))
 				
-				Expect(session.Out).To(gbytes.Say(fmt.Sprintf(`{"version":{"version":"3586.100"},"metadata":\[{"name":"url","value":"https://s3.amazonaws.com/bosh-core-stemcells/3586.100/bosh-stemcell-3586.100-azure-hyperv-ubuntu-trusty-go_agent.tgz"},{"name":"sha1","value":"%s"},{"name":"sha256","value":"%s"}\]}`, string(sha1Checksum), string(sha256Checksum))))
+				Expect(session.Out).To(gbytes.Say(fmt.Sprintf(`{"version":{"version":"3586.100"},"metadata":[{"name":"url","value":"https://s3.amazonaws.com/bosh-core-stemcells/3586.100/bosh-stemcell-3586.100-azure-hyperv-ubuntu-trusty-go_agent.tgz"},{"name":"sha1","value":"%s"},{"name":"sha256","value":"%s"}]}`, string(sha1Checksum), string(sha256Checksum))))
 			})
 		})
 	})
@@ -307,7 +307,7 @@ var _ = Describe("in", func() {
 				Expect(err).NotTo(HaveOccurred())
 				Expect(string(sha256Checksum)).To(Equal(fmt.Sprintf("%x", sha256.Sum256(tarballBytes))))
 				
-				Expect(session.Out).To(gbytes.Say(fmt.Sprintf(`{"version":{"version":"3586.100"},"metadata":\[{"name":"url","value":"https://s3.amazonaws.com/bosh-aws-light-stemcells/3586.100/light-bosh-stemcell-3586.100-aws-xen-hvm-ubuntu-trusty-go_agent.tgz"},{"name":"sha1","value":"%s"},{"name":"sha256","value":"%s"}\]}`, string(sha1Checksum), string(sha256Checksum))))
+				Expect(session.Out).To(gbytes.Say(fmt.Sprintf(`{"version":{"version":"3586.100"},"metadata":[{"name":"url","value":"https://s3.amazonaws.com/bosh-aws-light-stemcells/3586.100/light-bosh-stemcell-3586.100-aws-xen-hvm-ubuntu-trusty-go_agent.tgz"},{"name":"sha1","value":"%s"},{"name":"sha256","value":"%s"}]}`, string(sha1Checksum), string(sha256Checksum))))
 			})
 		})
 	})

--- a/acceptance/in_test.go
+++ b/acceptance/in_test.go
@@ -206,8 +206,9 @@ var _ = Describe("in", func() {
 
 			<-session.Exited
 			fmt.Println("---------------------------")
-			fmt.Printf("Error: %v\n", session.Err)
-			fmt.Printf("Output: %v\n", session.Out)
+			fmt.Println(string(session.Err.Contents()))
+			fmt.Println("-------------")
+			fmt.Println(string(session.Out.Contents()))
 			fmt.Println("---------------------------")
 			Expect(session.ExitCode()).To(Equal(0))
 

--- a/acceptance/in_test.go
+++ b/acceptance/in_test.go
@@ -25,7 +25,7 @@ const lightStemcellRequest = `
 		"tarball": false
 	},
 	"version": {
-		"version": "3262.4"
+		"version": "3586.100"
 	}
 }`
 
@@ -35,7 +35,7 @@ const regularStemcellRequest = `
 		"name": "bosh-azure-hyperv-ubuntu-trusty-go_agent"
 	},
 	"version": {
-		"version": "3262.9"
+		"version": "3586.100"
 	}
 }`
 
@@ -45,7 +45,7 @@ const bothTypesStemcellRequest = `
 		"name": "bosh-aws-xen-ubuntu-trusty-go_agent"
 	},
 	"version": {
-		"version": "3262.4"
+		"version": "3586.100"
 	}
 }`
 
@@ -56,7 +56,7 @@ const bothTypesForceRegularStemcellRequest = `
 		"force_regular": true
 	},
 	"version": {
-		"version": "3262.4"
+		"version": "3586.100"
 	}
 }`
 
@@ -69,7 +69,7 @@ const stemcellRequestWithFileName = `
 		"preserve_filename": true
 	},
 	"version": {
-		"version": "3262.12"
+		"version": "3586.100"
 	}
 }`
 
@@ -114,19 +114,19 @@ var _ = Describe("in", func() {
 
 				<-session.Exited
 				Expect(session.ExitCode()).To(Equal(0))
-				Expect(session.Out).To(gbytes.Say(`{"version":{"version":"3262.4"},"metadata":\[{"name":"url","value":"https://d26ekeud912fhb.cloudfront.net/bosh-stemcell/aws/light-bosh-stemcell-3262.4-aws-xen-hvm-ubuntu-trusty-go_agent.tgz"},{"name":"sha1","value":"58b80c916ad523defea9e661045b7fc700a9ec4f"}\]}`))
+				Expect(session.Out).To(gbytes.Say(`{"version":{"version":"3586.100"},"metadata":\[{"name":"url","value":"https://s3.amazonaws.com/bosh-aws-light-stemcells/3586.100/light-bosh-stemcell-3586.100-aws-xen-hvm-ubuntu-trusty-go_agent.tgz"},{"name":"sha1","value":"b78c60c1bc60d91d798bccc098180167c3c794fe"}\]}`))
 
 				version, err := ioutil.ReadFile(filepath.Join(contentDir, "version"))
 				Expect(err).NotTo(HaveOccurred())
-				Expect(string(version)).To(Equal("3262.4"))
+				Expect(string(version)).To(Equal("3586.100"))
 
 				url, err := ioutil.ReadFile(filepath.Join(contentDir, "url"))
 				Expect(err).NotTo(HaveOccurred())
-				Expect(string(url)).To(Equal("https://d26ekeud912fhb.cloudfront.net/bosh-stemcell/aws/light-bosh-stemcell-3262.4-aws-xen-hvm-ubuntu-trusty-go_agent.tgz"))
+				Expect(string(url)).To(Equal("https://s3.amazonaws.com/bosh-aws-light-stemcells/3586.100/light-bosh-stemcell-3586.100-aws-xen-hvm-ubuntu-trusty-go_agent.tgz"))
 
 				checksum, err := ioutil.ReadFile(filepath.Join(contentDir, "sha1"))
 				Expect(err).NotTo(HaveOccurred())
-				Expect(string(checksum)).To(Equal("58b80c916ad523defea9e661045b7fc700a9ec4f"))
+				Expect(string(checksum)).To(Equal("b78c60c1bc60d91d798bccc098180167c3c794fe"))
 			})
 		})
 	})
@@ -165,7 +165,7 @@ var _ = Describe("in", func() {
 				checksum, err := ioutil.ReadFile(filepath.Join(contentDir, "sha1"))
 				Expect(err).NotTo(HaveOccurred())
 
-				Expect(session.Out).To(gbytes.Say(fmt.Sprintf(`{"version":{"version":"3262.9"},"metadata":\[{"name":"url","value":"https://s3.amazonaws.com/bosh-azure-stemcells/bosh-stemcell-3262.9-azure-hyperv-ubuntu-trusty-go_agent.tgz"},{"name":"sha1","value":"%s"}\]}`, string(checksum))))
+				Expect(session.Out).To(gbytes.Say(fmt.Sprintf(`{"version":{"version":"3586.100"},"metadata":\[{"name":"url","value":"https://s3.amazonaws.com/bosh-azure-stemcells/bosh-stemcell-3586.100-azure-hyperv-ubuntu-trusty-go_agent.tgz"},{"name":"sha1","value":"%s"}\]}`, string(checksum))))
 				Expect(string(checksum)).To(Equal(fmt.Sprintf("%x", sha1.Sum(tarballBytes))))
 			})
 		})
@@ -279,11 +279,11 @@ var _ = Describe("in", func() {
 				<-session.Exited
 				Expect(session.ExitCode()).To(Equal(0))
 
-				tarballBytes, err := ioutil.ReadFile(filepath.Join(contentDir, "light-bosh-stemcell-3262.12-aws-xen-hvm-ubuntu-trusty-go_agent.tgz"))
+				tarballBytes, err := ioutil.ReadFile(filepath.Join(contentDir, "light-bosh-stemcell-3586.100-aws-xen-hvm-ubuntu-trusty-go_agent.tgz"))
 				Expect(err).NotTo(HaveOccurred())
 
 				checksum, err := ioutil.ReadFile(filepath.Join(contentDir, "sha1"))
-				Expect(session.Out).To(gbytes.Say(fmt.Sprintf(`{"version":{"version":"3262.12"},"metadata":\[{"name":"url","value":"https://d26ekeud912fhb.cloudfront.net/bosh-stemcell/aws/light-bosh-stemcell-3262.12-aws-xen-hvm-ubuntu-trusty-go_agent.tgz"},{"name":"sha1","value":"%s"}\]}`, string(checksum))))
+				Expect(session.Out).To(gbytes.Say(fmt.Sprintf(`{"version":{"version":"3586.100"},"metadata":\[{"name":"url","value":"https://s3.amazonaws.com/bosh-azure-stemcells/bosh-stemcell-3586.100-azure-hyperv-ubuntu-trusty-go_agent.tgz"},{"name":"sha1","value":"%s"}\]}`, string(checksum))))
 
 				Expect(err).NotTo(HaveOccurred())
 				Expect(string(checksum)).To(Equal(fmt.Sprintf("%x", sha1.Sum(tarballBytes))))

--- a/acceptance/in_test.go
+++ b/acceptance/in_test.go
@@ -43,7 +43,7 @@ const regularStemcellRequest = `
 const bothTypesStemcellRequest = `
 {
 	"source": {
-		"name": "bosh-aws-xen-ubuntu-trusty-go_agent"
+		"name": "bosh-aws-xen-hvm-ubuntu-trusty-go_agent"
 	},
 	"version": {
 		"version": "3586.100"
@@ -53,7 +53,7 @@ const bothTypesStemcellRequest = `
 const bothTypesForceRegularStemcellRequest = `
 {
 	"source": {
-		"name": "bosh-aws-xen-ubuntu-trusty-go_agent",
+		"name": "bosh-aws-xen-hvm-ubuntu-trusty-go_agent",
 		"force_regular": true
 	},
 	"version": {
@@ -200,11 +200,7 @@ var _ = Describe("in", func() {
 			Expect(err).NotTo(HaveOccurred())
 		})
 
-		FIt("downloads the light stemcell with metadata", func() {
-			fmt.Println("boshioIn---------------------")
-			fmt.Println(boshioIn)
-			fmt.Println("---------------------")
-
+		It("downloads the light stemcell with metadata", func() {
 			session, err := gexec.Start(command, GinkgoWriter, GinkgoWriter)
 			Expect(err).NotTo(HaveOccurred())
 

--- a/acceptance/in_test.go
+++ b/acceptance/in_test.go
@@ -205,6 +205,10 @@ var _ = Describe("in", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			<-session.Exited
+			fmt.Println("---------------------------")
+			fmt.Println(session.Err)
+			fmt.Println(session.Out)
+			fmt.Println("---------------------------")
 			Expect(session.ExitCode()).To(Equal(0))
 
 			tarballBytes, err := ioutil.ReadFile(filepath.Join(contentDir, "stemcell.tgz"))

--- a/acceptance/in_test.go
+++ b/acceptance/in_test.go
@@ -3,6 +3,7 @@ package acceptance_test
 import (
 	"bytes"
 	"crypto/sha1"
+	"crypto/sha256"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -114,7 +115,7 @@ var _ = Describe("in", func() {
 
 				<-session.Exited
 				Expect(session.ExitCode()).To(Equal(0))
-				Expect(session.Out).To(gbytes.Say(`{"version":{"version":"3586.100"},"metadata":\[{"name":"url","value":"https://s3.amazonaws.com/bosh-aws-light-stemcells/3586.100/light-bosh-stemcell-3586.100-aws-xen-hvm-ubuntu-trusty-go_agent.tgz"},{"name":"sha1","value":"b78c60c1bc60d91d798bccc098180167c3c794fe"}\]}`))
+				Expect(session.Out).To(gbytes.Say(`{"version":{"version":"3586.100"},"metadata":\[{"name":"url","value":"https://s3.amazonaws.com/bosh-aws-light-stemcells/3586.100/light-bosh-stemcell-3586.100-aws-xen-hvm-ubuntu-trusty-go_agent.tgz"},{"name":"sha1","value":"b78c60c1bc60d91d798bccc098180167c3c794fe"},{"name":"sha256","value":"e03853323c7f5636e78a6322935274ba9acbcd525e967f5e609c3a3fcf3e7ab9"}\]}`))
 
 				version, err := ioutil.ReadFile(filepath.Join(contentDir, "version"))
 				Expect(err).NotTo(HaveOccurred())
@@ -124,9 +125,13 @@ var _ = Describe("in", func() {
 				Expect(err).NotTo(HaveOccurred())
 				Expect(string(url)).To(Equal("https://s3.amazonaws.com/bosh-aws-light-stemcells/3586.100/light-bosh-stemcell-3586.100-aws-xen-hvm-ubuntu-trusty-go_agent.tgz"))
 
-				checksum, err := ioutil.ReadFile(filepath.Join(contentDir, "sha1"))
+				sha1Checksum, err := ioutil.ReadFile(filepath.Join(contentDir, "sha1"))
 				Expect(err).NotTo(HaveOccurred())
-				Expect(string(checksum)).To(Equal("b78c60c1bc60d91d798bccc098180167c3c794fe"))
+				Expect(string(sha1Checksum)).To(Equal("b78c60c1bc60d91d798bccc098180167c3c794fe"))
+
+				sha256Checksum, err := ioutil.ReadFile(filepath.Join(contentDir, "sha256"))
+				Expect(err).NotTo(HaveOccurred())
+				Expect(string(sha256Checksum)).To(Equal("e03853323c7f5636e78a6322935274ba9acbcd525e967f5e609c3a3fcf3e7ab9"))
 			})
 		})
 	})
@@ -162,11 +167,15 @@ var _ = Describe("in", func() {
 				tarballBytes, err := ioutil.ReadFile(filepath.Join(contentDir, "stemcell.tgz"))
 				Expect(err).NotTo(HaveOccurred())
 
-				checksum, err := ioutil.ReadFile(filepath.Join(contentDir, "sha1"))
+				sha1Checksum, err := ioutil.ReadFile(filepath.Join(contentDir, "sha1"))
 				Expect(err).NotTo(HaveOccurred())
+				Expect(string(sha1Checksum)).To(Equal(fmt.Sprintf("%x", sha1.Sum(tarballBytes))))
 
-				Expect(session.Out).To(gbytes.Say(fmt.Sprintf(`{"version":{"version":"3586.100"},"metadata":\[{"name":"url","value":"https://s3.amazonaws.com/bosh-azure-stemcells/bosh-stemcell-3586.100-azure-hyperv-ubuntu-trusty-go_agent.tgz"},{"name":"sha1","value":"%s"}\]}`, string(checksum))))
-				Expect(string(checksum)).To(Equal(fmt.Sprintf("%x", sha1.Sum(tarballBytes))))
+				sha256Checksum, err := ioutil.ReadFile(filepath.Join(contentDir, "sha256"))
+				Expect(err).NotTo(HaveOccurred())
+				Expect(string(sha256Checksum)).To(Equal(fmt.Sprintf("%x", sha256.Sum256(tarballBytes))))
+				
+				Expect(session.Out).To(gbytes.Say(fmt.Sprintf(`{"version":{"version":"3586.100"},"metadata":\[{"name":"url","value":"https://s3.amazonaws.com/bosh-azure-stemcells/bosh-stemcell-3586.100-azure-hyperv-ubuntu-trusty-go_agent.tgz"},{"name":"sha1","value":"%s"},{"name":"sha256","value":"%s"}\]}`, string(sha1Checksum), string(sha256Checksum))))
 			})
 		})
 	})
@@ -201,9 +210,13 @@ var _ = Describe("in", func() {
 			tarballBytes, err := ioutil.ReadFile(filepath.Join(contentDir, "stemcell.tgz"))
 			Expect(err).NotTo(HaveOccurred())
 
-			checksum, err := ioutil.ReadFile(filepath.Join(contentDir, "sha1"))
+			sha1Checksum, err := ioutil.ReadFile(filepath.Join(contentDir, "sha1"))
 			Expect(err).NotTo(HaveOccurred())
-			Expect(string(checksum)).To(Equal(fmt.Sprintf("%x", sha1.Sum(tarballBytes))))
+			Expect(string(sha1Checksum)).To(Equal(fmt.Sprintf("%x", sha1.Sum(tarballBytes))))
+
+			sha256Checksum, err := ioutil.ReadFile(filepath.Join(contentDir, "sha256"))
+			Expect(err).NotTo(HaveOccurred())
+			Expect(string(sha256Checksum)).To(Equal(fmt.Sprintf("%x", sha256.Sum256(tarballBytes))))
 
 			urlBytes, err := ioutil.ReadFile(filepath.Join(contentDir, "url"))
 			Expect(err).NotTo(HaveOccurred())
@@ -241,9 +254,13 @@ var _ = Describe("in", func() {
 			tarballBytes, err := ioutil.ReadFile(filepath.Join(contentDir, "stemcell.tgz"))
 			Expect(err).NotTo(HaveOccurred())
 
-			checksum, err := ioutil.ReadFile(filepath.Join(contentDir, "sha1"))
+			sha1Checksum, err := ioutil.ReadFile(filepath.Join(contentDir, "sha1"))
 			Expect(err).NotTo(HaveOccurred())
-			Expect(string(checksum)).To(Equal(fmt.Sprintf("%x", sha1.Sum(tarballBytes))))
+			Expect(string(sha1Checksum)).To(Equal(fmt.Sprintf("%x", sha1.Sum(tarballBytes))))
+
+			sha256Checksum, err := ioutil.ReadFile(filepath.Join(contentDir, "sha256"))
+			Expect(err).NotTo(HaveOccurred())
+			Expect(string(sha256Checksum)).To(Equal(fmt.Sprintf("%x", sha256.Sum256(tarballBytes))))
 
 			urlBytes, err := ioutil.ReadFile(filepath.Join(contentDir, "url"))
 			Expect(err).NotTo(HaveOccurred())
@@ -282,11 +299,15 @@ var _ = Describe("in", func() {
 				tarballBytes, err := ioutil.ReadFile(filepath.Join(contentDir, "light-bosh-stemcell-3586.100-aws-xen-hvm-ubuntu-trusty-go_agent.tgz"))
 				Expect(err).NotTo(HaveOccurred())
 
-				checksum, err := ioutil.ReadFile(filepath.Join(contentDir, "sha1"))
-				Expect(session.Out).To(gbytes.Say(fmt.Sprintf(`{"version":{"version":"3586.100"},"metadata":\[{"name":"url","value":"https://s3.amazonaws.com/bosh-azure-stemcells/bosh-stemcell-3586.100-azure-hyperv-ubuntu-trusty-go_agent.tgz"},{"name":"sha1","value":"%s"}\]}`, string(checksum))))
-
+				sha1Checksum, err := ioutil.ReadFile(filepath.Join(contentDir, "sha1"))
 				Expect(err).NotTo(HaveOccurred())
-				Expect(string(checksum)).To(Equal(fmt.Sprintf("%x", sha1.Sum(tarballBytes))))
+				Expect(string(sha1Checksum)).To(Equal(fmt.Sprintf("%x", sha1.Sum(tarballBytes))))
+
+				sha256Checksum, err := ioutil.ReadFile(filepath.Join(contentDir, "sha256"))
+				Expect(err).NotTo(HaveOccurred())
+				Expect(string(sha256Checksum)).To(Equal(fmt.Sprintf("%x", sha256.Sum256(tarballBytes))))
+				
+				Expect(session.Out).To(gbytes.Say(fmt.Sprintf(`{"version":{"version":"3586.100"},"metadata":\[{"name":"url","value":"https://s3.amazonaws.com/bosh-azure-stemcells/bosh-stemcell-3586.100-azure-hyperv-ubuntu-trusty-go_agent.tgz"},{"name":"sha1","value":"%s"},{"name":"sha256","value":"%s"}\]}`, string(sha1Checksum), string(sha256Checksum))))
 			})
 		})
 	})

--- a/acceptance/in_test.go
+++ b/acceptance/in_test.go
@@ -175,7 +175,7 @@ var _ = Describe("in", func() {
 				Expect(err).NotTo(HaveOccurred())
 				Expect(string(sha256Checksum)).To(Equal(fmt.Sprintf("%x", sha256.Sum256(tarballBytes))))
 				
-				Expect(session.Out).To(gbytes.Say(fmt.Sprintf(`{"version":{"version":"3586.100"},"metadata":\[{"name":"url","value":"https://s3.amazonaws.com/bosh-azure-stemcells/bosh-stemcell-3586.100-azure-hyperv-ubuntu-trusty-go_agent.tgz"},{"name":"sha1","value":"%s"},{"name":"sha256","value":"%s"}\]}`, string(sha1Checksum), string(sha256Checksum))))
+				Expect(session.Out).To(gbytes.Say(fmt.Sprintf(`{"version":{"version":"3586.100"},"metadata":\[{"name":"url","value":"https://s3.amazonaws.com/bosh-core-stemcells/3586.100/bosh-stemcell-3586.100-azure-hyperv-ubuntu-trusty-go_agent.tgz"},{"name":"sha1","value":"%s"},{"name":"sha256","value":"%s"}\]}`, string(sha1Checksum), string(sha256Checksum))))
 			})
 		})
 	})
@@ -307,7 +307,7 @@ var _ = Describe("in", func() {
 				Expect(err).NotTo(HaveOccurred())
 				Expect(string(sha256Checksum)).To(Equal(fmt.Sprintf("%x", sha256.Sum256(tarballBytes))))
 				
-				Expect(session.Out).To(gbytes.Say(fmt.Sprintf(`{"version":{"version":"3586.100"},"metadata":\[{"name":"url","value":"https://s3.amazonaws.com/bosh-azure-stemcells/bosh-stemcell-3586.100-azure-hyperv-ubuntu-trusty-go_agent.tgz"},{"name":"sha1","value":"%s"},{"name":"sha256","value":"%s"}\]}`, string(sha1Checksum), string(sha256Checksum))))
+				Expect(session.Out).To(gbytes.Say(fmt.Sprintf(`{"version":{"version":"3586.100"},"metadata":\[{"name":"url","value":"https://s3.amazonaws.com/bosh-aws-light-stemcells/3586.100/light-bosh-stemcell-3586.100-aws-xen-hvm-ubuntu-trusty-go_agent.tgz"},{"name":"sha1","value":"%s"},{"name":"sha256","value":"%s"}\]}`, string(sha1Checksum), string(sha256Checksum))))
 			})
 		})
 	})


### PR DESCRIPTION
In our CI, we're getting test failures in the build job that look like this:

```
#16 19.75 github.com/concourse/bosh-io-stemcell-resource/acceptance/in_test.go:89
#16 19.75   when a regular stemcell is requested
#16 19.75   github.com/concourse/bosh-io-stemcell-resource/acceptance/in_test.go:134
#16 19.75     when the tarball is requested
#16 19.75     github.com/concourse/bosh-io-stemcell-resource/acceptance/in_test.go:154
#16 19.75       downloads the stemcell with metadata
#16 19.75       github.com/concourse/bosh-io-stemcell-resource/acceptance/in_test.go:155
#16 19.75 ------------------------------
#16 20.96 2024/07/19 01:08:49 Head "https://d26ekeud912fhb.cloudfront.net/bosh-stemcell/aws/light-bosh-stemcell-3262.4-aws-xen-ubuntu-trusty-go_agent.tgz": dial tcp: lookup d26ekeud912fhb.cloudfront.net on 10.12.0.10:53: no such host
#16 20.96 • Failure [1.207 seconds]
#16 20.96 in
#16 20.96 github.com/concourse/bosh-io-stemcell-resource/acceptance/in_test.go:89
#16 20.96   when a stemcell is requested that supports both light and regular
#16 20.96   github.com/concourse/bosh-io-stemcell-resource/acceptance/in_test.go:174
#16 20.96     downloads the light stemcell with metadata [It]
#16 20.96     github.com/concourse/bosh-io-stemcell-resource/acceptance/in_test.go:194
#16 20.96 
#16 20.96     Expected
#16 20.96         <int>: 1
#16 20.96     to equal
#16 20.96         <int>: 0
#16 20.96 
#16 20.96     github.com/concourse/bosh-io-stemcell-resource/acceptance/in_test.go:199
```

The cause seems to be that the stemcell URL in the fixture is no longer available.

These changes update the url and the respective version in the fixtures.

New stemcell API response: https://bosh.io/api/v1/stemcells/bosh-aws-xen-hvm-ubuntu-trusty-go_agent?all=1. Note the url and the addition of sha256.